### PR TITLE
Fix/sql server commands

### DIFF
--- a/BookInventory/Data/ICommands Interfaces.cs
+++ b/BookInventory/Data/ICommands Interfaces.cs
@@ -6,24 +6,24 @@ using System.Collections.Generic;
 
 namespace BookInventory
 {
-    public interface IAddBookCommand
+    internal interface IAddBookCommand
     {
         bool AddBook(IBook book);
     }//IAddBookCommand
-    public interface IRemoveBookCommand
+    internal interface IRemoveBookCommand
     {
         bool RemoveBook(IBook book);
     }//IRemoveBook
-    public interface IUpdateBookCommand
+    internal interface IUpdateBookCommand
     {
         bool UpdateBook(IBook book);
     }//IUpdateBook
-    public interface ILoadingBooksCommand
+    internal interface ILoadingBooksCommand
     {
         IEnumerable<IBook> LoadAllBooks();
         IBook FindBookByISBN(string isbn);
     }//ILoadingBook
-    public interface IFilterBooksCommand
+    internal interface IFilterBooksCommand
     {
         IEnumerable<IBook> FilterBooks(Predicate<IBook> predicate);
         IEnumerable<IBook> FilterBooks(bool matchAllCriteria, string authorName = null, string authorSurname = null, string genre = null, string title = null);

--- a/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerAddCommand.cs
+++ b/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerAddCommand.cs
@@ -44,11 +44,11 @@ namespace BookInventory
                 //-If Book_ID = NULL --> Then the transaction was not complete
                 //      - Otherwise it was complete
 
-                if (cmd.Parameters["@Book_ID"].Value is null)
-                    return false;
+                //if (cmd.Parameters["@Book_ID"].Value is null)
+                //    return false;
 
                 //Update the Book_ID
-                ((Book)book).ID = int.Parse(cmd.Parameters["@Book_ID"].Value.ToString());
+
 
                 //Here the book and the respective authors were added to the database
                 //-The returned table will be of the form:
@@ -57,13 +57,17 @@ namespace BookInventory
                 //NOTE:
                 //- The order in which the author string was created is the order in which the ID's are created
                 //- The number of records return is equal to the number of authors in the "book.BookAuthors" properties
-
                 foreach (IAuthor author in book.BookAuthors)
                 {
                     if (rd.Read())
                     {
                         //Update the author ID
                         ((Author)author).ID = int.Parse(rd["Author_ID"].ToString());
+
+                        //Update the bookID
+                        //-The book ID will remain the same for all the authors
+                        if(book.ID == default)
+                            ((Book)book).ID = int.Parse(rd["Book_ID"].ToString());
                     }//end if
                 }//end foreach
                 return true;

--- a/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerFilterCommand.cs
+++ b/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerFilterCommand.cs
@@ -32,6 +32,10 @@ namespace BookInventory
             IList<IBook> books = new List<IBook>(); 
             try
             {
+                //Check if the connections is open
+                if (_dbService.GetConnection().State == ConnectionState.Closed)
+                    _dbService.GetConnection().Open();
+
                 //Create the command
                 SqlCommand cmd = new SqlCommand("proc_FilterBook", (SqlConnection)_dbService.GetConnection());
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerFilterCommand.cs
+++ b/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerFilterCommand.cs
@@ -29,6 +29,16 @@ namespace BookInventory
 
         public IEnumerable<IBook> FilterBooks(bool matchAllCriteria, string authorName = null, string authorSurname = null, string genre = null, string title = null)
         {
+            //Set the null values to a default value to ensure that the stored procedure receives a valid value.
+            //-This prevents null-related errors in the SQL procedure, allowing for proper filtering of books.
+            if (authorName == null)
+                authorName = "";
+            if (authorSurname == null)
+                authorSurname = "";
+            if (title == null)
+                title = "";
+            if (genre == null)
+                genre = "";
             IList<IBook> books = new List<IBook>(); 
             try
             {

--- a/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerFilterCommand.cs
+++ b/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerFilterCommand.cs
@@ -41,7 +41,7 @@ namespace BookInventory
                 cmd.CommandType = CommandType.StoredProcedure;
 
                 //Pass the parameters
-                cmd.Parameters.AddWithValue("@Book_Title ", title);
+                cmd.Parameters.AddWithValue("@Book_Title", title);
                 cmd.Parameters.AddWithValue("@Genre", genre);
                 cmd.Parameters.AddWithValue("@AuthorName", authorName);
                 cmd.Parameters.AddWithValue("@AuthorSurname", authorSurname);

--- a/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerLoadingCommand.cs
+++ b/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerLoadingCommand.cs
@@ -27,7 +27,7 @@ namespace BookInventory
                 //Create a command tha will use the stored procedure for loading a new book
                 SqlCommand cmd = new SqlCommand("proc_FindBookByISBN", (SqlConnection)_dbService.GetConnection());
                 cmd.CommandType = CommandType.StoredProcedure;
-                cmd.Parameters.AddWithValue("@@BookISBN", isbn);
+                cmd.Parameters.AddWithValue("@BookISBN", isbn);
 
                 //Execute the command
                 SqlDataReader rd = cmd.ExecuteReader();

--- a/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerRemoveCommand.cs
+++ b/BookInventory/Data/SQLServerDB/SQLServerCommands/SQLServerRemoveCommand.cs
@@ -21,14 +21,14 @@ namespace BookInventory
                     _dbService.GetConnection().Open();
 
                 //Create the sql command
-                SqlCommand cmd = new SqlCommand("pro_RemoveBook", (SqlConnection)_dbService.GetConnection());
+                SqlCommand cmd = new SqlCommand("proc_RemoveBook", (SqlConnection)_dbService.GetConnection());
                 cmd.CommandType = CommandType.StoredProcedure;
                 cmd.Parameters.AddWithValue("@BookID", book.ID);
 
                 int result = cmd.ExecuteNonQuery();
 
                 //If result is "1" then it was a successful transaction otherwise it failed
-                return result == 1;
+                return result >= 1;
             }
             catch
             (Exception ex)

--- a/BookInventory/Models/Author.cs
+++ b/BookInventory/Models/Author.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace BookInventory
 {
-    public class Author : IAuthor
+    internal class Author : IAuthor
     {
         public int ID { get; internal set; } = default;
 

--- a/BookInventory/Models/Book.cs
+++ b/BookInventory/Models/Book.cs
@@ -20,7 +20,7 @@ namespace BookInventory
 
         public int PublicationYear { get; private set; }
 
-        public IEnumerable<IAuthor> BookAuthors { get; private set; }
+        public IEnumerable<IAuthor> BookAuthors { get; internal set; }
         public Book(string isbn, string title, string genre, IEnumerable<IAuthor> authors, int publicationYear, int quantity = 1)
         {
             this.ISBN = isbn;

--- a/BookInventory/Utilities/SQLServerUtility.cs
+++ b/BookInventory/Utilities/SQLServerUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.Globalization;
 
 namespace BookInventory.Utilities
 {
@@ -71,8 +72,8 @@ namespace BookInventory.Utilities
                     string auth_name = rd["Author_Name"].ToString();
                     string auth_Surname = rd["Author_Surname"].ToString();
                     int noPub = int.Parse(rd["AuthorPublications"].ToString());
-                    DateTime dob = DateTime.ParseExact(rd["DOB"].ToString(), "yyyy/MM/dd", null);
 
+                    DateTime dob = DateTime.ParseExact(rd["DOB"].ToString(), "yyyy/MM/dd HH:mm:ss", new CultureInfo("en-ZA"), DateTimeStyles.None);
                     //Create the author
                     ICreationResult<IAuthor> resultAuthor = AuthorFactory.CreateAuthor(auth_name, auth_Surname, noPub, dob);
                     //Asume the data is correct(since it comes from the database)

--- a/SQL Server Database Files/Stored Procedures Scripts/Proc_AddNewBook.sql
+++ b/SQL Server Database Files/Stored Procedures Scripts/Proc_AddNewBook.sql
@@ -105,7 +105,7 @@ BEGIN
 
             --Here we might need to also check if we are not duplicating authors(autho)
             --Check if an author with the same names exists
-            SET @AuthorID_test = (SELECT Author_ID FROM Author WHERE Author_Name = @AuthorName AND Author_Surname = @AuthorSurname AND DOB = @DOB);
+            SET @AuthorID_test = (SELECT Top 1 Author_ID FROM Author WHERE Author_Name = @AuthorName AND Author_Surname = @AuthorSurname AND DOB = @DOB);
 
             IF @AuthorID_test IS NOT NULL
             BEGIN
@@ -115,9 +115,12 @@ BEGIN
                 WHERE AuthorName = @AuthorName
                 AND   AuthorSurname = @AuthorSurname
                 AND DOB = @DOB;
+
+                --Update the authorID 
+                SET @AuthorID = @AuthorID_test;
             END
             --Check if the author exists(by id)
-            IF NOT EXISTS (SELECT Author_Name FROM Author WHERE Author_ID = @AuthorID)
+            ELSE IF NOT EXISTS (SELECT Author_Name FROM Author WHERE Author_ID = @AuthorID)
             BEGIN
                 --Create a new author record
                 INSERT INTO Author(Author_Name, Author_Surname, Publications, DOB)

--- a/SQL Server Database Files/Stored Procedures Scripts/proc_FilterBooks.sql
+++ b/SQL Server Database Files/Stored Procedures Scripts/proc_FilterBooks.sql
@@ -40,8 +40,8 @@ BEGIN
     --     - Find books by author name 'J.K.' or surname 'Rowling':
     --       EXEC proc_FilterBook @AuthorName = 'J.K.', @AuthorSurname = 'owling', @MustContainValues = 0;
     -- =====================================================================
-*/
-    --The default values should all be null
+    */
+    
     DECLARE @Sql          VARCHAR(MAX),
             @BracketAdded BIT;
 
@@ -61,12 +61,11 @@ BEGIN
                 FROM Book   
                 INNER JOIN BookAuthor ON BookAuthor.Book_ID = Book.Book_ID 
                 INNER JOIN Author ON BookAuthor.Author_ID = Author.Author_ID 
-                WHERE 1 =1 ';--Add a default statement for the filter criteria, this will allow for filtering before joining other tables
-                                                 --    and also for future extension of the ceode(adding new filtering conditions)
--- Initialize a flag to determine if any filters have been added
+                WHERE 1 =1 '; 
+
     DECLARE @FilterAdded BIT = 0;
 
-    IF(@Book_Title IS NOT NULL)
+    IF(@Book_Title IS NOT NULL AND @Book_Title <> '')
     BEGIN
         IF @MustContainValues = 1
             SET @Sql = @Sql + ' AND Book.Book_Title LIKE ''%' + @Book_Title + '%''';
@@ -77,7 +76,7 @@ BEGIN
         END
     END
 
-    IF(@Genre IS NOT NULL)
+    IF(@Genre IS NOT NULL AND @Genre <> '')
     BEGIN
         IF @MustContainValues = 1
             SET @Sql = @Sql + ' AND Genre LIKE ''%' + @Genre + '%''';
@@ -93,7 +92,7 @@ BEGIN
         END
     END
 
-    IF(@AuthorName IS NOT NULL)
+    IF(@AuthorName IS NOT NULL AND @AuthorName <> '')
     BEGIN
         IF @MustContainValues = 1
             SET @Sql = @Sql + ' AND Author.Author_Name LIKE ''%' + @AuthorName + '%''';
@@ -109,7 +108,7 @@ BEGIN
         END
     END
 
-    IF(@AuthorSurname IS NOT NULL)
+    IF(@AuthorSurname IS NOT NULL AND @AuthorSurname <> '')
     BEGIN
         IF @MustContainValues = 1
             SET @Sql = @Sql + ' AND Author.Author_Surname LIKE ''%' + @AuthorSurname + '%''';
@@ -125,7 +124,6 @@ BEGIN
         END
     END
 
-    -- Close the grouping if any OR conditions were added
     IF @FilterAdded = 1
         SET @Sql = @Sql + ' )'; 
 


### PR DESCRIPTION
# Pull Request: Fix SQL Server Commands

## Summary

This pull request addresses several fixes and improvements to the SQL Server commands in the repository. Key changes include updates to stored procedures and command logic to ensure proper execution and results handling.

## Changes Made

### 1. RemoveBook Command
- Corrected the procedure name from `pro_RemoveBook` to `proc_RemovedBook`, ensuring the correct stored procedure is called when removing a book.

### 2. AddBook Command and Procedure
- Addressed an issue with the output parameter for the book ID, which was always returning `null`. Now using a result table to retrieve the book ID on the client side.
- Modified the result table's header for the book ID from `BookID` to `Book_ID`, ensuring consistency across the application.
- Ensured the first author's ID is correctly linked when searching if the author exists.
- Updated the procedure to correctly update the temporary table for author IDs.

## Additional Fixes
- **FilterBooks**: Changed null checks to empty string checks in both the `proc_FilterBooks` procedure and C# client, addressing an issue where passing `null` values caused the SQL engine to not receive parameters.
- **SQLUtility Class**: Updated the `ReadToListOfBooks` method to fix date of birth parsing for authors and improve the logic for handling books and their associated authors.
- **FilterBooks Command**: Fixed the issue with a white character in the `@BookTitle` parameter and ensured the connection is opened before executing commands.

## Testing & Validation
- All changes have been tested for correctness, with improvements made to error handling and logging. SQL operations, including adding, removing, and filtering books, now work as expected.

